### PR TITLE
Normalize database identifiers for case-insensitive access

### DIFF
--- a/Data/TagDbContext.cs
+++ b/Data/TagDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using SmartDocumentReview.Models;
 
 namespace SmartDocumentReview.Data
@@ -10,5 +11,26 @@ namespace SmartDocumentReview.Data
         public DbSet<User> Users { get; set; }
         public DbSet<Document> Documents { get; set; }
         public DbSet<TagMatch> TagMatches { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            // Convert table and column names to lower case to make comparisons case-insensitive
+            foreach (var entity in modelBuilder.Model.GetEntityTypes())
+            {
+                var tableName = entity.GetTableName();
+                if (!string.IsNullOrEmpty(tableName))
+                {
+                    entity.SetTableName(tableName.ToLowerInvariant());
+                }
+
+                foreach (var property in entity.GetProperties())
+                {
+                    var columnName = property.GetColumnBaseName();
+                    property.SetColumnName(columnName.ToLowerInvariant());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Ensure all EF Core table and column names are mapped to lower case to ignore identifier casing.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688fb1d90e64832ca4c5382156334373