### PR TITLE
Load tag matches from database and tidy upload layout

### DIFF
--- a/Pages/Review.razor
+++ b/Pages/Review.razor
@@ -1,13 +1,39 @@
-
 @page "/review"
 @using SmartDocumentReview.Services
 @using SmartDocumentReview.Models
+@using SmartDocumentReview.Data
+@using System.Linq
 @inject AuthService AuthService
+@inject TagDbContext Db
 
 <h3>Review Page</h3>
 <p>Hi @AuthService.CurrentUser, here are your tag matches:</p>
 
-@* Example usage of TagMatch model *@
+@if (matches.Any())
+{
+    <ul class="list-disc pl-5">
+        @foreach (var match in matches)
+        {
+            <li class="mb-2">
+                <strong>@match.Keyword</strong> - @match.SectionTitle (Page @match.PageNumber)
+                <div>@match.MatchedText</div>
+            </li>
+        }
+    </ul>
+}
+else
+{
+    <p>No matches found.</p>
+}
+
 @code {
     private List<TagMatch> matches = new();
+
+    protected override void OnInitialized()
+    {
+        matches = Db.TagMatches
+            .Where(t => t.CreatedBy == AuthService.CurrentUser)
+            .OrderByDescending(t => t.CreatedAt)
+            .ToList();
+    }
 }

--- a/Pages/Upload.razor
+++ b/Pages/Upload.razor
@@ -18,8 +18,8 @@
 
             <EditForm Model="this" OnValidSubmit="HandleValidSubmit">
                 <div class="flex flex-col md:flex-row gap-4">
-                    <InputFile class="w-full px-3 py-2 border border-gray-300 rounded-lg" OnChange="HandleFileSelected" accept=".pdf" />
-                    <div class="flex-1">
+                    <InputFile class="w-full md:w-1/3 px-3 py-2 border border-gray-300 rounded-lg" OnChange="HandleFileSelected" accept=".pdf" />
+                    <div class="flex-1 md:w-2/3">
                         <label class="block mb-2 text-sm font-medium text-gray-700">Enter up to 5 keywords (one per line):</label>
                         <InputTextArea class="w-full px-3 py-2 border border-gray-300 rounded-lg" @bind-Value="RawKeywordInput" Rows="6" />
                     </div>


### PR DESCRIPTION
## Summary
- Display saved tag matches for the current user on the review page
- Give upload file and keyword entry fields distinct widths for clearer layout

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688fc4ba5ac4832cb325573ab37d5fe3