### PR TITLE
Remove unused PdfProcessor service

### DIFF
--- a/Services/PdfProcessor.cs
+++ b/Services/PdfProcessor.cs
@@ -1,1 +1,0 @@
-// PdfProcessor: extract matches by keyword


### PR DESCRIPTION
## Summary
- remove obsolete `PdfProcessor` placeholder to prevent mistaken usage.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688fcb784520832c89ff24078bd26dc1