### PR TITLE
Keep PDF stream open after processing

### DIFF
--- a/Services/PdfKeywordTagger.cs
+++ b/Services/PdfKeywordTagger.cs
@@ -12,6 +12,7 @@ namespace SmartDocumentReview.Services
             var matches = new List<TagMatch>();
 
             using var reader = new PdfReader(pdfStream);
+            reader.SetCloseStream(false);
             using var pdf = new PdfDocument(reader);
 
             for (int i = 1; i <= pdf.GetNumberOfPages(); i++)


### PR DESCRIPTION
## Summary
- Prevent `PdfReader` from closing the underlying stream so uploads remain usable after keyword processing

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fcffbbee4832c976f3ec857b9fafa