### PR TITLE
Support highlighting multiple keywords simultaneously

### DIFF
--- a/Pages/PDFResult.razor
+++ b/Pages/PDFResult.razor
@@ -2,6 +2,8 @@
 @inject NavigationManager Navigation
 @inject SmartDocumentReview.Services.ResultStateService ResultStateService
 @inject IJSRuntime JS
+@using System.Linq
+@using System.Text.RegularExpressions
 
 <h3>Matched Results</h3>
 
@@ -11,11 +13,11 @@
         @foreach (var match in ResultStateService.Matches)
         {
             <div style="margin-bottom: 1.5rem;">
-                <h4 @onclick="() => LoadPdf(match.PageNumber, match.Keyword)" 
+                <h4 @onclick="() => LoadPdf(match.PageNumber)"
                     style="cursor: pointer; color: blue; text-decoration: underline;">
                     @match.SectionTitle
                 </h4>
-                <p>@(HighlightKeyword(match.MatchedText, match.Keyword))</p>
+                <p>@(HighlightKeywords(match.MatchedText))</p>
             </div>
         }
     </div>
@@ -27,27 +29,39 @@
 </div>
 
 @code {
+    private readonly string[] HighlightPalette = new[] { "#ffff00", "#ffb6c1", "#90ee90", "#add8e6", "#ffa07a" };
+    private Dictionary<string, string> keywordColors = new();
+
     protected override void OnInitialized()
     {
+        var keywords = ResultStateService.Matches.Select(m => m.Keyword).Distinct().ToList();
+        keywordColors = keywords.Select((k, i) => new { k, i }).ToDictionary(x => x.k, x => HighlightPalette[x.i % HighlightPalette.Length]);
+
         // Load first match by default
         if (ResultStateService.Matches.Count > 0)
         {
             var first = ResultStateService.Matches[0];
-            LoadPdf(first.PageNumber, first.Keyword);
+            LoadPdf(first.PageNumber);
         }
     }
 
-    void LoadPdf(int page, string keyword)
+    void LoadPdf(int page)
     {
         var file = "/uploads/latest.pdf";
-        var viewerUrl = $"/pdfjs/index.html?file={file}&page={page}&highlight={keyword}";
+        var highlightParams = string.Join("&", keywordColors.Select(kvp => $"highlight={Uri.EscapeDataString(kvp.Key)}&color={Uri.EscapeDataString(kvp.Value)}"));
+        var viewerUrl = $"/pdfjs/index.html?file={file}&page={page}&{highlightParams}";
         JS.InvokeVoidAsync("setIframeSrc", "pdfViewer", viewerUrl);
     }
 
-    MarkupString HighlightKeyword(string text, string keyword)
+    MarkupString HighlightKeywords(string text)
     {
-        if (string.IsNullOrWhiteSpace(keyword)) return (MarkupString)text;
-        var highlighted = text.Replace(keyword, $"<mark>{keyword}</mark>", StringComparison.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(text)) return (MarkupString)text;
+        var highlighted = text;
+        foreach (var kvp in keywordColors)
+        {
+            var regex = new Regex(Regex.Escape(kvp.Key), RegexOptions.IgnoreCase);
+            highlighted = regex.Replace(highlighted, m => $"<mark style=\"background-color: {kvp.Value};\">{m.Value}</mark>");
+        }
         return (MarkupString)highlighted;
     }
 }

--- a/Pages/Upload.razor
+++ b/Pages/Upload.razor
@@ -5,6 +5,7 @@
 @using SmartDocumentReview.Data
 @using System.IO
 @using System.Text.RegularExpressions
+@using System.Linq
 @inject AuthService AuthService
 @inject PdfKeywordTagger Tagger
 @inject TagDbContext Db
@@ -70,11 +71,11 @@
             @foreach (var match in MatchedKeywords)
             {
                 <div style="margin-bottom: 1.5rem;">
-                    <h4 @onclick="() => LoadPdf(match.PageNumber, match.Keyword)"
+                    <h4 @onclick="() => LoadPdf(match.PageNumber)"
                         style="cursor: pointer; color: blue; text-decoration: underline;">
                         @match.SectionTitle
                     </h4>
-                    <p>@(HighlightKeyword(match.MatchedText, match.Keyword))</p>
+                    <p>@(HighlightKeywords(match.MatchedText))</p>
                 </div>
             }
         </div>
@@ -191,7 +192,7 @@
 
             if (MatchedKeywords.Count > 0)
             {
-                LoadPdf(MatchedKeywords[0].PageNumber, MatchedKeywords[0].Keyword);
+                LoadPdf(MatchedKeywords[0].PageNumber);
             }
         }
         catch (Exception ex)
@@ -207,20 +208,23 @@
         }
     }
 
-    void LoadPdf(int page, string keyword)
+    void LoadPdf(int page)
     {
         var file = "/uploads/latest.pdf";
-        var color = keywordColors.ContainsKey(keyword) ? keywordColors[keyword] : "yellow";
-        var viewerUrl = $"/pdfjs/index.html?file={file}&page={page}&highlight={Uri.EscapeDataString(keyword)}&color={Uri.EscapeDataString(color)}";
+        var highlightParams = string.Join("&", keywordColors.Select(kvp => $"highlight={Uri.EscapeDataString(kvp.Key)}&color={Uri.EscapeDataString(kvp.Value)}"));
+        var viewerUrl = $"/pdfjs/index.html?file={file}&page={page}&{highlightParams}";
         JS.InvokeVoidAsync("setIframeSrc", "pdfViewer", viewerUrl);
     }
 
-    MarkupString HighlightKeyword(string text, string keyword)
+    MarkupString HighlightKeywords(string text)
     {
-        if (string.IsNullOrWhiteSpace(keyword)) return (MarkupString)text;
-        var color = keywordColors.ContainsKey(keyword) ? keywordColors[keyword] : "yellow";
-        var regex = new Regex(Regex.Escape(keyword), RegexOptions.IgnoreCase);
-        var highlighted = regex.Replace(text, m => $"<mark style=\"background-color: {color};\">{m.Value}</mark>");
+        if (string.IsNullOrWhiteSpace(text)) return (MarkupString)text;
+        var highlighted = text;
+        foreach (var kvp in keywordColors)
+        {
+            var regex = new Regex(Regex.Escape(kvp.Key), RegexOptions.IgnoreCase);
+            highlighted = regex.Replace(highlighted, m => $"<mark style=\"background-color: {kvp.Value};\">{m.Value}</mark>");
+        }
         return (MarkupString)highlighted;
     }
 }

--- a/wwwroot/pdfjs/index.html
+++ b/wwwroot/pdfjs/index.html
@@ -17,8 +17,8 @@
     const urlParams = new URLSearchParams(window.location.search);
     const file = urlParams.get('file') || '';
     const page = parseInt(urlParams.get('page') || '1', 10);
-    const highlight = urlParams.get('highlight') || '';
-    const color = urlParams.get('color') || 'yellow';
+    const highlights = urlParams.getAll('highlight');
+    const colors = urlParams.getAll('color');
     const container = document.getElementById('viewerContainer');
     pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.worker.min.js';
 
@@ -44,10 +44,15 @@
             viewport,
             textDivs: []
           }).promise.then(() => {
-            if (highlight) {
-              const regex = new RegExp(highlight, 'gi');
+            if (highlights.length > 0) {
               textLayerDiv.querySelectorAll('span').forEach(span => {
-                span.innerHTML = span.textContent.replace(regex, match => `<mark style="background-color: ${color};">${match}</mark>`);
+                let html = span.textContent;
+                highlights.forEach((h, i) => {
+                  const regex = new RegExp(h, 'gi');
+                  const c = colors[i] || 'yellow';
+                  html = html.replace(regex, match => `<mark style="background-color: ${c};">${match}</mark>`);
+                });
+                span.innerHTML = html;
               });
             }
           });


### PR DESCRIPTION
## Summary
- Allow PDF viewer to accept multiple `highlight` and `color` parameters and mark all occurrences
- Pass all keywords and colors when loading a PDF page
- Highlight all keywords in result snippets with their assigned colors

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688ff8d0ecac832cb6bd7c9cc285e1ed