### PR TITLE
Ensure PDF highlights render fully

### DIFF
--- a/wwwroot/pdfjs/index.html
+++ b/wwwroot/pdfjs/index.html
@@ -8,6 +8,8 @@
     #viewerContainer { position: relative; width: 100%; height: 100%; overflow: auto; }
     canvas { display: block; margin: auto; }
     mark { color: black; }
+    #viewerContainer .textLayer { opacity: 1 !important; }
+    #viewerContainer .textLayer mark { background: yellow; opacity: 1; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Override pdf.js text layer opacity so PDF annotations appear at full strength
- Ensure highlight marks retain full opacity

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688ffc8cd770832ca8c748ba5536f4fe