### PR TITLE
Escape highlight keywords in PDF viewer

### DIFF
--- a/wwwroot/pdfjs/index.html
+++ b/wwwroot/pdfjs/index.html
@@ -50,7 +50,8 @@
               textLayerDiv.querySelectorAll('span').forEach(span => {
                 const text = span.textContent;
                 highlights.forEach((h, i) => {
-                  const regex = new RegExp(h, 'gi');
+                  const escaped = h.replace(/[.*+?^${}()|[\]\\]/g, '\$&');
+                  const regex = new RegExp(escaped, 'gi');
                   let match;
                   while ((match = regex.exec(text)) !== null) {
                     const range = document.createRange();


### PR DESCRIPTION
## Summary
- Escape highlight keywords in `wwwroot/pdfjs/index.html` so special characters are treated literally.

## Testing
- `node - <<'NODE' ... NODE`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68901b33cc34832c83f139cabf26082c