### PR TITLE
Fix PDF keyword highlighting

### DIFF
--- a/wwwroot/pdfjs/index.html
+++ b/wwwroot/pdfjs/index.html
@@ -8,7 +8,7 @@
     #viewerContainer { position: relative; width: 100%; height: 100%; overflow: auto; }
     canvas { display: block; margin: auto; }
     #viewerContainer .textLayer { opacity: 1 !important; }
-    .highlight-overlay { position: absolute; pointer-events: none; opacity: 0.4; }
+    .text-highlight { background-color: yellow; }
   </style>
 </head>
 <body>
@@ -46,31 +46,14 @@
             textDivs: []
           }).promise.then(() => {
             if (highlights.length > 0) {
-              const layerRect = textLayerDiv.getBoundingClientRect();
               textLayerDiv.querySelectorAll('span').forEach(span => {
-                const text = span.textContent;
+                let html = span.innerHTML;
                 highlights.forEach((h, i) => {
                   const escaped = h.replace(/[.*+?^${}()|[\]\\]/g, '\$&');
                   const regex = new RegExp(escaped, 'gi');
-                  let match;
-                  while ((match = regex.exec(text)) !== null) {
-                    const range = document.createRange();
-                    range.setStart(span.firstChild, match.index);
-                    range.setEnd(span.firstChild, match.index + match[0].length);
-                    const rects = range.getClientRects();
-                    rects.forEach(r => {
-                      const highlight = document.createElement('div');
-                      highlight.className = 'highlight-overlay';
-                      highlight.style.backgroundColor = colors[i] || 'yellow';
-                      highlight.style.left = `${r.left - layerRect.left}px`;
-                      highlight.style.top = `${r.top - layerRect.top}px`;
-                      highlight.style.width = `${r.width}px`;
-                      highlight.style.height = `${r.height}px`;
-                      textLayerDiv.appendChild(highlight);
-                    });
-                    range.detach();
-                  }
+                  html = html.replace(regex, m => `<span class="text-highlight" style="background-color: ${colors[i] || 'yellow'};">${m}</span>`);
                 });
+                span.innerHTML = html;
               });
             }
           });


### PR DESCRIPTION
## Summary
- highlight keywords directly inside pdf.js text layer spans
- include default style for highlighted text

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68901e157d4c832c947e296c2bd1bcc8