### PR TITLE
Fix PDF highlight overlay

### DIFF
--- a/wwwroot/pdfjs/index.html
+++ b/wwwroot/pdfjs/index.html
@@ -8,7 +8,9 @@
     #viewerContainer { position: relative; width: 100%; height: 100%; overflow: auto; }
     canvas { display: block; margin: auto; }
     #viewerContainer .textLayer { opacity: 1 !important; }
-    .text-highlight { background-color: yellow; }
+    .text-highlight {
+      mix-blend-mode: multiply;
+    }
   </style>
 </head>
 <body>
@@ -51,7 +53,10 @@
                 highlights.forEach((h, i) => {
                   const escaped = h.replace(/[.*+?^${}()|[\]\\]/g, '\$&');
                   const regex = new RegExp(escaped, 'gi');
-                  html = html.replace(regex, m => `<span class="text-highlight" style="background-color: ${colors[i] || 'yellow'};">${m}</span>`);
+                  html = html.replace(
+                    regex,
+                    m => `<span class="text-highlight" style="background-color: ${colors[i] || 'rgba(255,255,0,0.4)'}; opacity: 0.5;">${m}</span>`
+                  );
                 });
                 span.innerHTML = html;
               });


### PR DESCRIPTION
## Summary
- make PDF highlight overlay semi-transparent and blend with page content
- ensure keyword highlights use opacity to avoid obscuring text

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689020415008832cbd200fe161c90380