### PR TITLE
Improve PDF keyword highlighting accuracy

### DIFF
--- a/Pages/PDFResult.razor
+++ b/Pages/PDFResult.razor
@@ -59,7 +59,9 @@
         var highlighted = text;
         foreach (var kvp in keywordColors)
         {
-            var regex = new Regex(Regex.Escape(kvp.Key), RegexOptions.IgnoreCase);
+            var escaped = Regex.Escape(kvp.Key);
+            var pattern = Regex.IsMatch(kvp.Key, @"\W") ? escaped : $"\\b{escaped}\\b";
+            var regex = new Regex(pattern, RegexOptions.IgnoreCase);
             highlighted = regex.Replace(highlighted, m => $"<mark style=\"background-color: {kvp.Value};\">{m.Value}</mark>");
         }
         return (MarkupString)highlighted;

--- a/Pages/Upload.razor
+++ b/Pages/Upload.razor
@@ -216,7 +216,9 @@
         var highlighted = text;
         foreach (var kvp in keywordColors)
         {
-            var regex = new Regex(Regex.Escape(kvp.Key), RegexOptions.IgnoreCase);
+            var escaped = Regex.Escape(kvp.Key);
+            var pattern = Regex.IsMatch(kvp.Key, @"\W") ? escaped : $"\\b{escaped}\\b";
+            var regex = new Regex(pattern, RegexOptions.IgnoreCase);
             highlighted = regex.Replace(highlighted, m => $"<mark style=\"background-color: {kvp.Value};\">{m.Value}</mark>");
         }
         return (MarkupString)highlighted;

--- a/wwwroot/pdfjs/index.html
+++ b/wwwroot/pdfjs/index.html
@@ -41,24 +41,51 @@
         p.render({ canvasContext: context, viewport });
 
         p.getTextContent().then(textContent => {
+          const textDivs = [];
           pdfjsLib.renderTextLayer({
             textContent,
             container: textLayerDiv,
             viewport,
-            textDivs: []
+            textDivs
           }).promise.then(() => {
             if (highlights.length > 0) {
-              textLayerDiv.querySelectorAll('span').forEach(span => {
-                let html = span.innerHTML;
-                highlights.forEach((h, i) => {
-                  const escaped = h.replace(/[.*+?^${}()|[\]\\]/g, '\$&');
-                  const regex = new RegExp(escaped, 'gi');
-                  html = html.replace(
-                    regex,
-                    m => `<span class="text-highlight" style="background-color: ${colors[i] || 'rgba(255,255,0,0.4)'}; opacity: 0.5;">${m}</span>`
-                  );
+              const spans = textDivs;
+              let fullText = '';
+              const spanRanges = spans.map((span, idx) => {
+                const start = fullText.length;
+                const str = textContent.items[idx].str;
+                fullText += str;
+                return { start, end: fullText.length };
+              });
+              const perSpan = spans.map(() => []);
+              highlights.forEach((h, i) => {
+                const escaped = h.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                const hasNonWord = /\W/.test(h);
+                const regex = new RegExp(hasNonWord ? escaped : `\\b${escaped}\\b`, 'gi');
+                let match;
+                while ((match = regex.exec(fullText)) !== null) {
+                  const start = match.index;
+                  const end = start + match[0].length;
+                  spanRanges.forEach((range, idx) => {
+                    if (range.start < end && range.end > start) {
+                      const localStart = Math.max(start, range.start) - range.start;
+                      const localEnd = Math.min(end, range.end) - range.start;
+                      perSpan[idx].push({ start: localStart, end: localEnd, color: colors[i] || 'rgba(255,255,0,0.4)' });
+                    }
+                  });
+                }
+              });
+              perSpan.forEach((ranges, idx) => {
+                if (ranges.length === 0) return;
+                ranges.sort((a, b) => b.start - a.start);
+                let text = spans[idx].textContent;
+                ranges.forEach(r => {
+                  const before = text.slice(0, r.start);
+                  const middle = text.slice(r.start, r.end);
+                  const after = text.slice(r.end);
+                  text = `${before}<span class="text-highlight" style="background-color: ${r.color}; opacity:0.5;">${middle}</span>${after}`;
                 });
-                span.innerHTML = html;
+                spans[idx].innerHTML = text;
               });
             }
           });


### PR DESCRIPTION
## Summary
- Handle keyword highlights across PDF text spans and enforce whole-word matching
- Restrict keyword highlighting in Razor views to whole words

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890b0cbbe3c832c8f010904f72d6f25