### PR TITLE
Replace placeholder PdfProcessor with documentation

### DIFF
--- a/Services/PdfProcessor.cs
+++ b/Services/PdfProcessor.cs
@@ -1,1 +1,0 @@
-// PdfProcessor: extract matches by keyword

--- a/Services/PdfProcessor.md
+++ b/Services/PdfProcessor.md
@@ -1,0 +1,11 @@
+# PdfProcessor (planned)
+
+This document explains the intended role of the `PdfProcessor` service.
+Originally, `PdfProcessor.cs` existed as a placeholder without implementation.
+The service is expected to provide advanced PDF processing capabilities such as
+text extraction, metadata handling, or preparing documents for keyword tagging.
+
+The current application uses `PdfKeywordTagger` to locate keyword matches in PDFs.
+
+**TODO:** Implement the `PdfProcessor` service when additional PDF processing
+features are required.


### PR DESCRIPTION
## Summary
- remove unused `PdfProcessor.cs`
- document planned `PdfProcessor` service and TODO for future implementation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68912d829e14832ca1b35ff9b50afd91