### PR TITLE
Merge overlapping highlight ranges

### DIFF
--- a/wwwroot/pdfjs/index.html
+++ b/wwwroot/pdfjs/index.html
@@ -77,9 +77,23 @@
               });
               perSpan.forEach((ranges, idx) => {
                 if (ranges.length === 0) return;
-                ranges.sort((a, b) => b.start - a.start);
-                let text = spans[idx].textContent;
+                ranges.sort((a, b) => a.start - b.start);
+                const merged = [];
                 ranges.forEach(r => {
+                  if (merged.length === 0) {
+                    merged.push({ ...r });
+                  } else {
+                    const last = merged[merged.length - 1];
+                    if (r.start <= last.end) {
+                      last.end = Math.max(last.end, r.end);
+                    } else {
+                      merged.push({ ...r });
+                    }
+                  }
+                });
+                merged.sort((a, b) => b.start - a.start);
+                let text = spans[idx].textContent;
+                merged.forEach(r => {
                   const before = text.slice(0, r.start);
                   const middle = text.slice(r.start, r.end);
                   const after = text.slice(r.end);


### PR DESCRIPTION
## Summary
- merge overlapping or adjacent highlight ranges per span
- sort merged ranges descending before applying highlight

## Testing
- `node /tmp/test_highlight.js`
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68912d76f690832cb4dc311106b11790