### PR TITLE
Add option for partial keyword matches

### DIFF
--- a/Models/Keyword.cs
+++ b/Models/Keyword.cs
@@ -1,1 +1,10 @@
-// Keyword entity
+using System;
+
+namespace SmartDocumentReview.Models
+{
+    /// <summary>
+    /// Represents a keyword entered by the user.
+    /// When <see cref="AllowPartial"/> is true, the keyword may match inside other words.
+    /// </summary>
+    public record Keyword(string Text, bool AllowPartial);
+}

--- a/Pages/PDFResult.razor
+++ b/Pages/PDFResult.razor
@@ -4,6 +4,7 @@
 @inject IJSRuntime JS
 @using System.Linq
 @using System.Text.RegularExpressions
+@using SmartDocumentReview.Models
 
 <h3>Matched Results</h3>
 
@@ -30,11 +31,11 @@
 
 @code {
     private readonly string[] HighlightPalette = new[] { "#ffff00", "#ffb6c1", "#90ee90", "#add8e6", "#ffa07a" };
-    private Dictionary<string, string> keywordColors = new();
+    private Dictionary<Keyword, string> keywordColors = new();
 
     protected override void OnInitialized()
     {
-        var keywords = ResultStateService.Matches.Select(m => m.Keyword).Distinct().ToList();
+        var keywords = ResultStateService.Keywords;
         keywordColors = keywords.Select((k, i) => new { k, i }).ToDictionary(x => x.k, x => HighlightPalette[x.i % HighlightPalette.Length]);
 
         // Load first match by default
@@ -48,7 +49,7 @@
     void LoadPdf(int page)
     {
         var file = "/uploads/latest.pdf";
-        var highlightParams = string.Join("&", keywordColors.Select(kvp => $"highlight={Uri.EscapeDataString(kvp.Key)}&color={Uri.EscapeDataString(kvp.Value)}"));
+        var highlightParams = string.Join("&", keywordColors.Select(kvp => $"highlight={Uri.EscapeDataString(kvp.Key.Text)}&color={Uri.EscapeDataString(kvp.Value)}&partial={kvp.Key.AllowPartial.ToString().ToLower()}"));
         var viewerUrl = $"/pdfjs/index.html?file={file}&page={page}&{highlightParams}";
         JS.InvokeVoidAsync("setIframeSrc", "pdfViewer", viewerUrl);
     }
@@ -59,8 +60,8 @@
         var highlighted = text;
         foreach (var kvp in keywordColors)
         {
-            var escaped = Regex.Escape(kvp.Key);
-            var pattern = Regex.IsMatch(kvp.Key, @"\W") ? escaped : $"\\b{escaped}\\b";
+            var escaped = Regex.Escape(kvp.Key.Text);
+            var pattern = (kvp.Key.AllowPartial || Regex.IsMatch(kvp.Key.Text, @"\W")) ? escaped : $"\\b{escaped}\\b";
             var regex = new Regex(pattern, RegexOptions.IgnoreCase);
             highlighted = regex.Replace(highlighted, m => $"<mark style=\"background-color: {kvp.Value};\">{m.Value}</mark>");
         }

--- a/Pages/Upload.razor
+++ b/Pages/Upload.razor
@@ -10,6 +10,7 @@
 @inject PdfKeywordTagger Tagger
 @inject TagDbContext Db
 @inject IJSRuntime JS
+@inject ResultStateService ResultStateService
 
 <h3 class="mb-4 text-center">Smart Document Review</h3>
 
@@ -98,7 +99,7 @@
 
     public List<TagMatch> MatchedKeywords { get; set; } = new();
     private readonly string[] HighlightPalette = new[] { "#ffff00", "#ffb6c1", "#90ee90", "#add8e6", "#ffa07a" };
-    private Dictionary<string, string> keywordColors = new();
+    private Dictionary<Keyword, string> keywordColors = new();
 
     private readonly System.Diagnostics.Stopwatch _stopwatch = new();
     private System.Timers.Timer? _timer;
@@ -121,9 +122,13 @@
 
         var keywords = RawKeywordInput
             .Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
-            .Select(k => k.Trim())
-            .Where(k => !string.IsNullOrWhiteSpace(k))
-            .Distinct()
+            .Select(k => {
+                var trimmed = k.Trim();
+                var allowPartial = trimmed.StartsWith("*");
+                var text = allowPartial ? trimmed.TrimStart('*') : trimmed;
+                return new Keyword(text, allowPartial);
+            })
+            .Where(k => !string.IsNullOrWhiteSpace(k.Text))
             .Take(5)
             .ToList();
 
@@ -155,6 +160,8 @@
             memoryStream.Position = 0;
 
             MatchedKeywords = Tagger.ProcessPdf(memoryStream, keywords, AuthService.CurrentUser);
+            ResultStateService.Matches = MatchedKeywords;
+            ResultStateService.Keywords = keywords;
 
             // Save uploaded file for PDF viewer
             memoryStream.Position = 0;
@@ -205,7 +212,7 @@
     void LoadPdf(int page)
     {
         var file = "/uploads/latest.pdf";
-        var highlightParams = string.Join("&", keywordColors.Select(kvp => $"highlight={Uri.EscapeDataString(kvp.Key)}&color={Uri.EscapeDataString(kvp.Value)}"));
+        var highlightParams = string.Join("&", keywordColors.Select(kvp => $"highlight={Uri.EscapeDataString(kvp.Key.Text)}&color={Uri.EscapeDataString(kvp.Value)}&partial={kvp.Key.AllowPartial.ToString().ToLower()}"));
         var viewerUrl = $"/pdfjs/index.html?file={file}&page={page}&{highlightParams}";
         JS.InvokeVoidAsync("setIframeSrc", "pdfViewer", viewerUrl);
     }
@@ -216,8 +223,8 @@
         var highlighted = text;
         foreach (var kvp in keywordColors)
         {
-            var escaped = Regex.Escape(kvp.Key);
-            var pattern = Regex.IsMatch(kvp.Key, @"\W") ? escaped : $"\\b{escaped}\\b";
+            var escaped = Regex.Escape(kvp.Key.Text);
+            var pattern = (kvp.Key.AllowPartial || Regex.IsMatch(kvp.Key.Text, @"\W")) ? escaped : $"\\b{escaped}\\b";
             var regex = new Regex(pattern, RegexOptions.IgnoreCase);
             highlighted = regex.Replace(highlighted, m => $"<mark style=\"background-color: {kvp.Value};\">{m.Value}</mark>");
         }

--- a/Program.cs
+++ b/Program.cs
@@ -33,6 +33,7 @@ builder.Services.AddDbContext<TagDbContext>(options =>
 // Register services
 builder.Services.AddScoped<AuthService>();
 builder.Services.AddScoped<PdfKeywordTagger>();
+builder.Services.AddScoped<ResultStateService>();
 
 // Setup Razor/Blazor
 builder.Services.AddRazorPages();

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An AI-assisted web tool to extract and highlight relevant sections in PDF docume
 - Basic login (testuser / Test@123)
 - Audit fields: CreatedBy, CreatedAt, etc.
 - Built with Blazor Server + C# + PostgreSQL-ready
+- Prefix a keyword with `*` to match inside larger words (e.g. `*bank` matches "bankruptcy")
 
 ## Getting Started
 

--- a/Services/PdfKeywordTagger.cs
+++ b/Services/PdfKeywordTagger.cs
@@ -7,7 +7,7 @@ namespace SmartDocumentReview.Services
 {
     public class PdfKeywordTagger
     {
-        public List<TagMatch> ProcessPdf(Stream pdfStream, List<string> keywords, string createdBy)
+        public List<TagMatch> ProcessPdf(Stream pdfStream, List<Keyword> keywords, string createdBy)
         {
             var matches = new List<TagMatch>();
 
@@ -22,13 +22,16 @@ namespace SmartDocumentReview.Services
 
                 foreach (var keyword in keywords)
                 {
-                    var pattern = Regex.Escape(keyword);
-                    var regex = new Regex($@"(.{{0,60}}{pattern}.{{0,60}})", RegexOptions.IgnoreCase);
+                    var escaped = Regex.Escape(keyword.Text);
+                    var corePattern = (keyword.AllowPartial || Regex.IsMatch(keyword.Text, @"\W"))
+                        ? escaped
+                        : $"\\b{escaped}\\b";
+                    var regex = new Regex($@"(.{{0,60}}{corePattern}.{{0,60}})", RegexOptions.IgnoreCase);
                     foreach (Match match in regex.Matches(text))
                     {
                         matches.Add(new TagMatch
                         {
-                            Keyword = keyword,
+                            Keyword = keyword.Text,
                             SectionTitle = sectionTitle,
                             MatchedText = match.Value,
                             CreatedBy = createdBy,

--- a/Services/ResultStateService.cs
+++ b/Services/ResultStateService.cs
@@ -5,5 +5,6 @@ namespace SmartDocumentReview.Services
     public class ResultStateService
     {
         public List<TagMatch> Matches { get; set; } = new();
+        public List<Keyword> Keywords { get; set; } = new();
     }
 }

--- a/SmartDocumentReview.Tests/KeywordMatchTests.cs
+++ b/SmartDocumentReview.Tests/KeywordMatchTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.IO;
+using iText.Kernel.Pdf;
+using iText.Layout;
+using iText.Layout.Element;
+using SmartDocumentReview.Models;
+using SmartDocumentReview.Services;
+using Xunit;
+
+namespace SmartDocumentReview.Tests
+{
+    public class KeywordMatchTests
+    {
+        private MemoryStream CreatePdf(string text)
+        {
+            var ms = new MemoryStream();
+            using var writer = new PdfWriter(ms);
+            using var pdf = new PdfDocument(writer);
+            using var doc = new Document(pdf);
+            doc.Add(new Paragraph(text));
+            doc.Close();
+            ms.Position = 0;
+            return ms;
+        }
+
+        [Fact]
+        public void DoesNotMatchInsideWordWhenWholeWord()
+        {
+            using var pdf = CreatePdf("bankruptcy");
+            var tagger = new PdfKeywordTagger();
+            var keywords = new List<Keyword> { new Keyword("bank", false) };
+            var matches = tagger.ProcessPdf(pdf, keywords, "tester");
+            Assert.Empty(matches);
+        }
+
+        [Fact]
+        public void MatchesInsideWordWhenPartialAllowed()
+        {
+            using var pdf = CreatePdf("bankruptcy");
+            var tagger = new PdfKeywordTagger();
+            var keywords = new List<Keyword> { new Keyword("bank", true) };
+            var matches = tagger.ProcessPdf(pdf, keywords, "tester");
+            Assert.Single(matches);
+            Assert.Equal("bank", matches[0].Keyword);
+        }
+    }
+}

--- a/SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj
+++ b/SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SmartDocumentReview.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/wwwroot/pdfjs/index.html
+++ b/wwwroot/pdfjs/index.html
@@ -22,6 +22,7 @@
     const page = parseInt(urlParams.get('page') || '1', 10);
     const highlights = urlParams.getAll('highlight');
     const colors = urlParams.getAll('color');
+    const partials = urlParams.getAll('partial');
     const container = document.getElementById('viewerContainer');
     pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.worker.min.js';
 
@@ -61,7 +62,8 @@
               highlights.forEach((h, i) => {
                 const escaped = h.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
                 const hasNonWord = /\W/.test(h);
-                const regex = new RegExp(hasNonWord ? escaped : `\\b${escaped}\\b`, 'gi');
+                const allowPartial = partials[i] === 'true';
+                const regex = new RegExp((allowPartial || hasNonWord) ? escaped : `\\b${escaped}\\b`, 'gi');
                 let match;
                 while ((match = regex.exec(fullText)) !== null) {
                   const start = match.index;


### PR DESCRIPTION
## Summary
- Allow disabling word-boundary checks per keyword using a new `Keyword` model and `*` prefix syntax
- Pass boundary preference through highlight routines and PDF viewer, enabling matches inside longer words
- Document partial-match option and add regression tests for inside-word matching

## Testing
- `apt-get update >/tmp/apt.log` *(failed: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-19 InRelease' is not signed)*
- `dotnet test SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj` *(failed: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68912d7a740c832cad7bb9e49812ff62