### PR TITLE
Extract PDF text with positions for keyword matches

### DIFF
--- a/Models/PdfTextPosition.cs
+++ b/Models/PdfTextPosition.cs
@@ -1,0 +1,11 @@
+namespace SmartDocumentReview.Models
+{
+    public class PdfTextPosition
+    {
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Width { get; set; }
+        public float Height { get; set; }
+    }
+}
+

--- a/Models/TagMatch.cs
+++ b/Models/TagMatch.cs
@@ -13,5 +13,7 @@ namespace SmartDocumentReview.Models
         public DateTime CreatedAt { get; set; }
         public int DocumentId { get; set; }
         public int PageNumber { get; set; }
+        [NotMapped]
+        public List<PdfTextPosition> Positions { get; set; } = new();
     }
 }

--- a/Services/TextWithPositionExtractionStrategy.cs
+++ b/Services/TextWithPositionExtractionStrategy.cs
@@ -1,0 +1,52 @@
+using System.Text;
+using System.Collections.Generic;
+using iText.Kernel.Geom;
+using iText.Kernel.Pdf.Canvas.Parser;
+using iText.Kernel.Pdf.Canvas.Parser.Data;
+using iText.Kernel.Pdf.Canvas.Parser.Listener;
+using SmartDocumentReview.Models;
+
+namespace SmartDocumentReview.Services
+{
+    internal class TextCharWithPosition
+    {
+        public string Text { get; set; } = string.Empty;
+        public PdfTextPosition Position { get; set; } = new PdfTextPosition();
+    }
+
+    internal class TextWithPositionExtractionStrategy : IEventListener
+    {
+        private readonly StringBuilder _builder = new StringBuilder();
+        public List<TextCharWithPosition> Characters { get; } = new List<TextCharWithPosition>();
+
+        public void EventOccurred(IEventData data, EventType type)
+        {
+            if (type != EventType.RENDER_TEXT) return;
+            var renderInfo = (TextRenderInfo)data;
+            foreach (var charInfo in renderInfo.GetCharacterRenderInfos())
+            {
+                var glyph = charInfo.GetText();
+                _builder.Append(glyph);
+                var descent = charInfo.GetDescentLine().GetStartPoint();
+                var ascent = charInfo.GetAscentLine().GetEndPoint();
+                Characters.Add(new TextCharWithPosition
+                {
+                    Text = glyph,
+                    Position = new PdfTextPosition
+                    {
+                        X = descent.Get(0),
+                        Y = descent.Get(1),
+                        Width = ascent.Get(0) - descent.Get(0),
+                        Height = ascent.Get(1) - descent.Get(1)
+                    }
+                });
+            }
+        }
+
+        public ICollection<EventType> GetSupportedEvents()
+            => new HashSet<EventType> { EventType.RENDER_TEXT };
+
+        public string GetResultantText() => _builder.ToString();
+    }
+}
+

--- a/SmartDocumentReview.Tests/KeywordMatchTests.cs
+++ b/SmartDocumentReview.Tests/KeywordMatchTests.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using System.IO;
 using iText.Kernel.Pdf;
-using iText.Layout;
 using iText.Layout.Element;
+using iTextDocument = iText.Layout.Document;
 using SmartDocumentReview.Models;
 using SmartDocumentReview.Services;
 using Xunit;
@@ -15,8 +15,9 @@ namespace SmartDocumentReview.Tests
         {
             var ms = new MemoryStream();
             using var writer = new PdfWriter(ms);
+            writer.SetCloseStream(false);
             using var pdf = new PdfDocument(writer);
-            using var doc = new Document(pdf);
+            using var doc = new iTextDocument(pdf);
             doc.Add(new Paragraph(text));
             doc.Close();
             ms.Position = 0;

--- a/SmartDocumentReview.csproj
+++ b/SmartDocumentReview.csproj
@@ -20,4 +20,8 @@
     <PackageReference Include="itext7" Version="7.2.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="SmartDocumentReview.Tests/**/*.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- Use PdfCanvasProcessor with custom `TextWithPositionExtractionStrategy` to capture text and character positions
- Capture keyword match coordinates and expose them via `TagMatch.Positions`
- Adjust tests and project file to support position extraction

## Testing
- `~/.dotnet/dotnet test SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68913003eb58832c8847a02d65cc496b