### PR TITLE
Exclude test project from main build and fix PDF tests

### DIFF
--- a/SmartDocumentReview.Tests/KeywordMatchTests.cs
+++ b/SmartDocumentReview.Tests/KeywordMatchTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using iText.Kernel.Pdf;
-using iText.Layout;
+using iTextDocument = iText.Layout.Document;
 using iText.Layout.Element;
 using SmartDocumentReview.Models;
 using SmartDocumentReview.Services;
@@ -14,13 +14,13 @@ namespace SmartDocumentReview.Tests
         private MemoryStream CreatePdf(string text)
         {
             var ms = new MemoryStream();
-            using var writer = new PdfWriter(ms);
-            using var pdf = new PdfDocument(writer);
-            using var doc = new Document(pdf);
-            doc.Add(new Paragraph(text));
-            doc.Close();
-            ms.Position = 0;
-            return ms;
+            using (var writer = new PdfWriter(ms))
+            using (var pdf = new PdfDocument(writer))
+            using (var doc = new iTextDocument(pdf))
+            {
+                doc.Add(new Paragraph(text));
+            }
+            return new MemoryStream(ms.ToArray());
         }
 
         [Fact]

--- a/SmartDocumentReview.csproj
+++ b/SmartDocumentReview.csproj
@@ -18,6 +18,12 @@
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
     <PackageReference Include="itext7" Version="7.2.5" />
+    </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="SmartDocumentReview.Tests/**" />
+    <EmbeddedResource Remove="SmartDocumentReview.Tests/**" />
+    <None Remove="SmartDocumentReview.Tests/**" />
   </ItemGroup>
 
-</Project>
+  </Project>


### PR DESCRIPTION
## Summary
- prevent test sources from being included in the main web project
- fix test PDF generation by aliasing iText Document and keeping stream open

## Testing
- `dotnet test SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj -v q`


------
https://chatgpt.com/codex/tasks/task_e_689130468948832c8dbd1dd1beebe498