### PR TITLE
Fix PdfKeywordTagger compilation errors

### DIFF
--- a/Services/PdfKeywordTagger.cs
+++ b/Services/PdfKeywordTagger.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using iText.Kernel.Geom;
@@ -5,8 +8,6 @@ using iText.Kernel.Pdf;
 using iText.Kernel.Pdf.Canvas.Parser;
 using iText.Kernel.Pdf.Canvas.Parser.Listener;
 using SmartDocumentReview.Models;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace SmartDocumentReview.Services
 {
@@ -42,41 +43,41 @@ namespace SmartDocumentReview.Services
                 foreach (var keyword in keywords)
                 {
                     var escaped = Regex.Escape(keyword.Text);
-var escaped = Regex.Escape(keyword.Text);
-var pattern = (keyword.AllowPartial || Regex.IsMatch(keyword.Text, @"\w"))
-    ? escaped
-    : $@"\b{escaped}\b";
+                    var pattern = (keyword.AllowPartial || Regex.IsMatch(keyword.Text, @"\w"))
+                        ? escaped
+                        : $@"\b{escaped}\b";
 
-var regex = new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+                    var regex = new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
-foreach (Match match in regex.Matches(pageText))
-{
-    // Get the bounding box location from spans
-    IPdfTextLocation? loc = null;
-    if (spans.Count > 0)
-    {
-        var span = spans.FirstOrDefault(s => match.Index >= s.start && match.Index < s.end);
-        loc = span?.loc;
-    }
-    Rectangle rect = loc?.GetRectangle() ?? new Rectangle(0, 0, 0, 0);
+                    foreach (Match match in regex.Matches(pageText))
+                    {
+                        // Get the bounding box location from spans
+                        IPdfTextLocation? loc = null;
+                        if (spans.Count > 0)
+                        {
+                            var span = spans.FirstOrDefault(s => match.Index >= s.start && match.Index < s.end);
+                            loc = span.loc;
+                        }
+                        Rectangle rect = loc?.GetRectangle() ?? new Rectangle(0, 0, 0, 0);
 
-    // Extract matched context (±60 characters around the match)
-    var start = Math.Max(0, match.Index - 60);
-    var end = Math.Min(pageText.Length, match.Index + match.Length + 60);
-    var context = pageText.Substring(start, end - start);
+                        // Extract matched context (±60 characters around the match)
+                        var start = Math.Max(0, match.Index - 60);
+                        var end = Math.Min(pageText.Length, match.Index + match.Length + 60);
+                        var context = pageText.Substring(start, end - start);
 
-    matches.Add(new TagMatch
-    {
-        Keyword = keyword.Text,
-        SectionTitle = sectionTitle,
-        MatchedText = context,
-        CreatedBy = createdBy,
-        CreatedAt = DateTime.UtcNow,
-        PageNumber = i,
-        Rect = rect
-    });
-}
-
+                        matches.Add(new TagMatch
+                        {
+                            Keyword = keyword.Text,
+                            SectionTitle = sectionTitle,
+                            MatchedText = context,
+                            CreatedBy = createdBy,
+                            CreatedAt = DateTime.UtcNow,
+                            PageNumber = i,
+                            PageX = rect.GetX(),
+                            PageY = rect.GetY(),
+                            Width = rect.GetWidth(),
+                            Height = rect.GetHeight()
+                        });
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- fix `PdfKeywordTagger` method structure and remove stray lines
- map bounding box coordinates to `TagMatch` fields

## Testing
- `dotnet build`
- `dotnet test SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_689135a12900832c8a90e5a04f64e1f9