### PR TITLE
Fix TagMatch schema mismatch and regex matching

### DIFF
--- a/Models/TagMatch.cs
+++ b/Models/TagMatch.cs
@@ -16,6 +16,5 @@ namespace SmartDocumentReview.Models
         public float PageX { get; set; }
         public float PageY { get; set; }
         public float Width { get; set; }
-        public float Height { get; set; }
     }
 }

--- a/Services/PdfKeywordTagger.cs
+++ b/Services/PdfKeywordTagger.cs
@@ -43,7 +43,8 @@ namespace SmartDocumentReview.Services
                 foreach (var keyword in keywords)
                 {
                     var escaped = Regex.Escape(keyword.Text);
-                    var pattern = (keyword.AllowPartial || Regex.IsMatch(keyword.Text, @"\w"))
+                    // Use word boundaries when partial matches aren't allowed and keyword contains word chars
+                    var pattern = (keyword.AllowPartial || !Regex.IsMatch(keyword.Text, @"\w"))
                         ? escaped
                         : $@"\b{escaped}\b";
 
@@ -75,8 +76,7 @@ namespace SmartDocumentReview.Services
                             PageNumber = i,
                             PageX = rect.GetX(),
                             PageY = rect.GetY(),
-                            Width = rect.GetWidth(),
-                            Height = rect.GetHeight()
+                            Width = rect.GetWidth()
                         });
                     }
                 }

--- a/smart_document_review_schema.sql
+++ b/smart_document_review_schema.sql
@@ -31,7 +31,6 @@ CREATE TABLE TagMatches (
     PageX REAL,
     PageY REAL,
     Width REAL,
-    Height REAL,
     CreatedBy TEXT NOT NULL,
     CreatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UpdatedBy TEXT,


### PR DESCRIPTION
## Summary
- remove obsolete `Height` field from tag match storage
- avoid partial matches by using word boundaries when needed

## Testing
- `dotnet test SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6891379c08a0832c9e238d217e007376