### PR TITLE
Improve PDF keyword highlighting accuracy

### DIFF
--- a/Pages/PDFResult.razor
+++ b/Pages/PDFResult.razor
@@ -61,9 +61,11 @@
         foreach (var kvp in keywordColors)
         {
             var escaped = Regex.Escape(kvp.Key.Text);
-            var pattern = (kvp.Key.AllowPartial || Regex.IsMatch(kvp.Key.Text, @"\W")) ? escaped : $"\\b{escaped}\\b";
+            var pattern = kvp.Key.AllowPartial
+                ? escaped
+                : $@"(?<![\p{{L}}\p{{N}}]){escaped}(?![\p{{L}}\p{{N}}])";
             var regex = new Regex(pattern, RegexOptions.IgnoreCase);
-            highlighted = regex.Replace(highlighted, m => $"<mark style=\"background-color: {kvp.Value};\">{m.Value}</mark>");
+            highlighted = regex.Replace(highlighted, m => $"<mark style='background-color: {kvp.Value};'>{m.Value}</mark>");
         }
         return (MarkupString)highlighted;
     }

--- a/Pages/Upload.razor
+++ b/Pages/Upload.razor
@@ -224,9 +224,11 @@
         foreach (var kvp in keywordColors)
         {
             var escaped = Regex.Escape(kvp.Key.Text);
-            var pattern = (kvp.Key.AllowPartial || Regex.IsMatch(kvp.Key.Text, @"\W")) ? escaped : $"\\b{escaped}\\b";
+            var pattern = kvp.Key.AllowPartial
+                ? escaped
+                : $@"(?<![\p{{L}}\p{{N}}]){escaped}(?![\p{{L}}\p{{N}}])";
             var regex = new Regex(pattern, RegexOptions.IgnoreCase);
-            highlighted = regex.Replace(highlighted, m => $"<mark style=\"background-color: {kvp.Value};\">{m.Value}</mark>");
+            highlighted = regex.Replace(highlighted, m => $"<mark style='background-color: {kvp.Value};'>{m.Value}</mark>");
         }
         return (MarkupString)highlighted;
     }

--- a/Services/PdfKeywordTagger.cs
+++ b/Services/PdfKeywordTagger.cs
@@ -43,10 +43,10 @@ namespace SmartDocumentReview.Services
                 foreach (var keyword in keywords)
                 {
                     var escaped = Regex.Escape(keyword.Text);
-                    // Use word boundaries when partial matches aren't allowed and keyword contains word chars
-                    var pattern = (keyword.AllowPartial || !Regex.IsMatch(keyword.Text, @"\w"))
+                    // Use custom boundaries when partial matches aren't allowed to avoid partial word highlights
+                    var pattern = keyword.AllowPartial
                         ? escaped
-                        : $@"\b{escaped}\b";
+                        : $@"(?<![\p{{L}}\p{{N}}]){escaped}(?![\p{{L}}\p{{N}}])";
 
                     var regex = new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 

--- a/wwwroot/pdfjs/index.html
+++ b/wwwroot/pdfjs/index.html
@@ -61,9 +61,8 @@
               const perSpan = spans.map(() => []);
               highlights.forEach((h, i) => {
                 const escaped = h.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                const hasNonWord = /\W/.test(h);
                 const allowPartial = partials[i] === 'true';
-                const regex = new RegExp((allowPartial || hasNonWord) ? escaped : `\\b${escaped}\\b`, 'gi');
+                const regex = new RegExp(allowPartial ? escaped : `(?<![\\p{L}\\p{N}])${escaped}(?![\\p{L}\\p{N}])`, 'giu');
                 let match;
                 while ((match = regex.exec(fullText)) !== null) {
                   const start = match.index;


### PR DESCRIPTION
## Summary
- use custom Unicode-aware word boundaries to avoid partial keyword matches
- apply same boundary logic in Blazor highlight rendering
- update PDF.js viewer to respect whole-word matching

## Testing
- `dotnet test SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68913ae7b3c4832c834e1e5151104c08