### PR TITLE
Fix multi-keyword highlighting

### DIFF
--- a/Pages/PDFResult.razor
+++ b/Pages/PDFResult.razor
@@ -3,6 +3,7 @@
 @inject SmartDocumentReview.Services.ResultStateService ResultStateService
 @inject IJSRuntime JS
 @using System.Linq
+@using System.Text
 @using System.Text.RegularExpressions
 @using SmartDocumentReview.Models
 
@@ -67,16 +68,39 @@
     MarkupString HighlightKeywords(string text)
     {
         if (string.IsNullOrWhiteSpace(text)) return (MarkupString)text;
-        var highlighted = text;
+
+        var ranges = new List<(int start, int end, string color)>();
+
         foreach (var kvp in keywordColors)
         {
             var escaped = Regex.Escape(kvp.Key.Text);
             var pattern = kvp.Key.AllowPartial
                 ? escaped
                 : $@"(?<![\p{{L}}\p{{N}}]){escaped}(?![\p{{L}}\p{{N}}])";
-            var regex = new Regex(pattern, RegexOptions.IgnoreCase);
-            highlighted = regex.Replace(highlighted, m => $"<mark style='background-color: {kvp.Value};'>{m.Value}</mark>");
+            foreach (Match match in Regex.Matches(text, pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+            {
+                ranges.Add((match.Index, match.Index + match.Length, kvp.Value));
+            }
         }
-        return (MarkupString)highlighted;
+
+        if (ranges.Count == 0) return (MarkupString)text;
+
+        var ordered = ranges
+            .OrderBy(r => r.start)
+            .ThenByDescending(r => r.end - r.start)
+            .ToList();
+
+        var sb = new StringBuilder();
+        int last = 0;
+        foreach (var r in ordered)
+        {
+            if (r.start < last) continue; // skip overlaps
+            sb.Append(text[last..r.start]);
+            sb.Append($"<mark style='background-color: {r.color};'>{text[r.start..r.end]}</mark>");
+            last = r.end;
+        }
+        sb.Append(text[last..]);
+
+        return (MarkupString)sb.ToString();
     }
 }

--- a/Pages/Upload.razor
+++ b/Pages/Upload.razor
@@ -4,6 +4,7 @@
 @using SmartDocumentReview.Models
 @using SmartDocumentReview.Data
 @using System.IO
+@using System.Text
 @using System.Text.RegularExpressions
 @using System.Linq
 @inject AuthService AuthService
@@ -230,16 +231,39 @@
     MarkupString HighlightKeywords(string text)
     {
         if (string.IsNullOrWhiteSpace(text)) return (MarkupString)text;
-        var highlighted = text;
+
+        var ranges = new List<(int start, int end, string color)>();
+
         foreach (var kvp in keywordColors)
         {
             var escaped = Regex.Escape(kvp.Key.Text);
             var pattern = kvp.Key.AllowPartial
                 ? escaped
                 : $@"(?<![\p{{L}}\p{{N}}]){escaped}(?![\p{{L}}\p{{N}}])";
-            var regex = new Regex(pattern, RegexOptions.IgnoreCase);
-            highlighted = regex.Replace(highlighted, m => $"<mark style='background-color: {kvp.Value};'>{m.Value}</mark>");
+            foreach (Match match in Regex.Matches(text, pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+            {
+                ranges.Add((match.Index, match.Index + match.Length, kvp.Value));
+            }
         }
-        return (MarkupString)highlighted;
+
+        if (ranges.Count == 0) return (MarkupString)text;
+
+        var ordered = ranges
+            .OrderBy(r => r.start)
+            .ThenByDescending(r => r.end - r.start)
+            .ToList();
+
+        var sb = new StringBuilder();
+        int last = 0;
+        foreach (var r in ordered)
+        {
+            if (r.start < last) continue; // skip overlaps
+            sb.Append(text[last..r.start]);
+            sb.Append($"<mark style='background-color: {r.color};'>{text[r.start..r.end]}</mark>");
+            last = r.end;
+        }
+        sb.Append(text[last..]);
+
+        return (MarkupString)sb.ToString();
     }
 }


### PR DESCRIPTION
## Summary
- handle highlighting for any number of keywords without overlapping issues
- add System.Text usage for StringBuilder

## Testing
- `~/.dotnet/dotnet test SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68915bc82388832c89ebd15dc75261c0