### PR TITLE
feat: use PdfPig for keyword tagging

### DIFF
--- a/SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj
+++ b/SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="itext7" Version="7.2.5" />
     <ProjectReference Include="..\SmartDocumentReview.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/SmartDocumentReview.csproj
+++ b/SmartDocumentReview.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
-    <PackageReference Include="itext7" Version="7.2.5" />
+    <PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
     </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- replace reflection-based iText parsing with UglyToad.PdfPig for keyword coordinates
- add PdfPig package and remove iText from main project; ensure tests reference iText

## Testing
- `dotnet build`
- `dotnet test SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6891617cf2ac832ca5c984af4c29785a