### PR TITLE
fix: avoid whole-word matches with trailing punctuation

### DIFF
--- a/Services/PdfKeywordTagger.cs
+++ b/Services/PdfKeywordTagger.cs
@@ -39,10 +39,12 @@ namespace SmartDocumentReview.Services
                 foreach (var keyword in keywords)
                 {
                     var escaped = Regex.Escape(keyword.Text);
-                    // Use custom boundaries when partial matches aren't allowed to avoid partial word highlights
+                    // Use custom boundaries when partial matches aren't allowed to avoid partial word highlights.
+                    // Treat common word punctuation like apostrophes, hyphens and underscores as part of the word
+                    // to prevent matches such as "bank" in "bank's" when whole-word matching is requested.
                     var pattern = keyword.AllowPartial
                         ? escaped
-                        : $@"(?<![\p{{L}}\p{{N}}]){escaped}(?![\p{{L}}\p{{N}}])";
+                        : $@"(?<![\p{{L}}\p{{N}}_\u2019'-]){escaped}(?![\p{{L}}\p{{N}}_\u2019'-])";
 
                     var regex = new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 

--- a/SmartDocumentReview.Tests/KeywordMatchTests.cs
+++ b/SmartDocumentReview.Tests/KeywordMatchTests.cs
@@ -38,6 +38,16 @@ namespace SmartDocumentReview.Tests
         }
 
         [Fact]
+        public void DoesNotMatchWhenFollowedByApostropheInWholeWordSearch()
+        {
+            using var pdf = CreatePdf("bank's");
+            var tagger = new PdfKeywordTagger();
+            var keywords = new List<Keyword> { new Keyword("bank", false) };
+            var matches = tagger.ProcessPdf(pdf, keywords, "tester");
+            Assert.Empty(matches);
+        }
+
+        [Fact]
         public void MatchesInsideWordWhenPartialAllowed()
         {
             using var pdf = CreatePdf("bankruptcy");


### PR DESCRIPTION
## Summary
- avoid matching keywords in apostrophe-, hyphen-, or underscore-connected words
- add regression test for apostrophe cases

## Testing
- `dotnet test SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68916547908c832c8d4d17e5b0268833