### PR TITLE
Add Tesseract OCR fallback for scanned PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An AI-assisted web tool to extract and highlight relevant sections in PDF docume
 - Audit fields: CreatedBy, CreatedAt, etc.
 - Built with Blazor Server + C# + PostgreSQL-ready
 - Prefix a keyword with `*` to match inside larger words (e.g. `*bank` matches "bankruptcy")
+- Falls back to [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) for scanned PDFs (requires `tesseract-ocr` and `poppler-utils`)
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- add Tesseract-based OCR fallback when PDF text extraction fails
- document OCR dependency in README

## Testing
- `dotnet test SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6891658ccf90832cb8e023e718adb3ba