### PR TITLE
Group PDF matches by page

### DIFF
--- a/Pages/PDFResult.razor
+++ b/Pages/PDFResult.razor
@@ -14,14 +14,20 @@
 <div style="display: flex; height: 90vh;">
     <!-- Left: Match Results -->
     <div style="width: 40%; overflow-y: auto; padding: 1rem;">
-        @foreach (var match in ResultStateService.Matches)
+        @foreach (var pageGroup in ResultStateService.Matches.GroupBy(m => m.PageNumber))
         {
             <div style="margin-bottom: 1.5rem;">
-                <h4 @onclick="() => LoadPdfAsync(match.PageNumber)"
+                <h4 @onclick="() => LoadPdfAsync(pageGroup.Key)"
                     style="cursor: pointer; color: blue; text-decoration: underline;">
-                    @match.SectionTitle
+                    Page @pageGroup.Key
                 </h4>
-                <p>@(HighlightKeywords(match.MatchedText))</p>
+                @foreach (var match in pageGroup)
+                {
+                    <div style="margin-left: 1rem; margin-bottom: 0.75rem;">
+                        <strong>@match.SectionTitle</strong>
+                        <p>@(HighlightKeywords(match.MatchedText))</p>
+                    </div>
+                }
             </div>
         }
     </div>

--- a/Pages/Upload.razor
+++ b/Pages/Upload.razor
@@ -65,14 +65,20 @@
 {
     <div class="mt-4" style="display: flex; height: 90vh;">
         <div style="width: 40%; overflow-y: auto; padding: 1rem;">
-            @foreach (var match in MatchedKeywords)
+            @foreach (var pageGroup in MatchedKeywords.GroupBy(m => m.PageNumber))
             {
                 <div style="margin-bottom: 1.5rem;">
-                    <h4 @onclick="() => LoadPdfAsync(match.PageNumber)"
+                    <h4 @onclick="() => LoadPdfAsync(pageGroup.Key)"
                         style="cursor: pointer; color: blue; text-decoration: underline;">
-                        @match.SectionTitle
+                        Page @pageGroup.Key
                     </h4>
-                    <p>@(HighlightKeywords(match.MatchedText))</p>
+                    @foreach (var match in pageGroup)
+                    {
+                        <div style="margin-left: 1rem; margin-bottom: 0.75rem;">
+                            <strong>@match.SectionTitle</strong>
+                            <p>@(HighlightKeywords(match.MatchedText))</p>
+                        </div>
+                    }
                 </div>
             }
         </div>

--- a/Services/ResultStateService.cs
+++ b/Services/ResultStateService.cs
@@ -1,4 +1,5 @@
 using SmartDocumentReview.Models;
+using System.Linq;
 
 namespace SmartDocumentReview.Services
 {
@@ -6,5 +7,7 @@ namespace SmartDocumentReview.Services
     {
         public List<TagMatch> Matches { get; set; } = new();
         public List<Keyword> Keywords { get; set; } = new();
+
+        public IEnumerable<IGrouping<int, TagMatch>> GroupByPage() => Matches.GroupBy(m => m.PageNumber);
     }
 }


### PR DESCRIPTION
## Summary
- group match listings by page in Upload and PDF results views
- add helper to ResultStateService for grouping matches

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_689753da5600832c9a20359fce897e28