### PR TITLE
Ensure PDF viewer scrolls to requested page after placeholder build

### DIFF
--- a/wwwroot/pdfjs/index.html
+++ b/wwwroot/pdfjs/index.html
@@ -252,6 +252,7 @@
       }
 
       try { await buildSlotsInBatches(); } catch (e) { console.warn('slot build interrupted', e); }
+      viewerContainer.scrollTop = slots[startP - 1].slot.offsetTop;
       mark('all placeholders built');
 
       // ---- IntersectionObserver (observe only after slots exist) ----


### PR DESCRIPTION
## Summary
- keep requested page visible by scrolling to its slot after building placeholders

## Testing
- `dotnet test SmartDocumentReview.Tests/SmartDocumentReview.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6897a9907514832c955a5de6890d00cc