### PR TITLE
Load PDF viewer without JS

### DIFF
--- a/Pages/PDFResult.razor
+++ b/Pages/PDFResult.razor
@@ -1,7 +1,6 @@
 @page "/results"
 @inject NavigationManager Navigation
 @inject SmartDocumentReview.Services.ResultStateService ResultStateService
-@inject IJSRuntime JS
 @using System.Linq
 @using System.Text
 @using System.Text.RegularExpressions
@@ -17,7 +16,7 @@
         @foreach (var pageGroup in ResultStateService.Matches.GroupBy(m => m.PageNumber))
         {
             <div style="margin-bottom: 1.5rem;">
-                <h4 @onclick="() => LoadPdfAsync(pageGroup.Key)"
+                <h4 @onclick="async () => await LoadPdfAsync(pageGroup.Key)"
                     style="cursor: pointer; color: blue; text-decoration: underline;">
                     Page @pageGroup.Key
                 </h4>
@@ -34,7 +33,7 @@
 
     <!-- Right: PDF Viewer -->
     <div style="width: 60%; height: 100%;">
-        <iframe id="pdfViewer" width="100%" height="100%" frameborder="0"></iframe>
+        <iframe id="pdfViewer" src="@viewerSrc" width="100%" height="100%" frameborder="0"></iframe>
     </div>
 </div>
 
@@ -42,6 +41,7 @@
     private readonly string[] HighlightPalette = new[] { "#ffff00", "#ffb6c1", "#90ee90", "#add8e6", "#ffa07a" };
     private Dictionary<Keyword, string> keywordColors = new();
     private int? _pendingPage;
+    private string? viewerSrc;
 
     protected override void OnInitialized()
     {
@@ -68,8 +68,7 @@
     {
         var file = "/uploads/latest.pdf";
         var overlay = "/uploads/latest-highlights.json"; // Use same overlay as Upload.razor
-        var viewerUrl = $"/pdfjs/index.html?file={Uri.EscapeDataString(file)}&page={page}&overlay={Uri.EscapeDataString(overlay)}";
-        await JS.InvokeVoidAsync("setIframeSrc", "pdfViewer", viewerUrl);
+        viewerSrc = $"/pdfjs/index.html?file={Uri.EscapeDataString(file)}&page={page}&overlay={Uri.EscapeDataString(overlay)}";
     }
 
     MarkupString HighlightKeywords(string text)

--- a/Pages/Upload.razor
+++ b/Pages/Upload.razor
@@ -13,7 +13,6 @@
 @inject AuthService AuthService
 @inject PdfKeywordTagger Tagger
 @inject TagDbContext Db
-@inject IJSRuntime JS
 @inject ResultStateService ResultStateService
 
 <h3 class="mb-4 text-center">Smart Document Review</h3>
@@ -68,7 +67,7 @@
             @foreach (var pageGroup in MatchedKeywords.GroupBy(m => m.PageNumber))
             {
                 <div style="margin-bottom: 1.5rem;">
-                    <h4 @onclick="() => LoadPdfAsync(pageGroup.Key)"
+                    <h4 @onclick="async () => await LoadPdfAsync(pageGroup.Key)"
                         style="cursor: pointer; color: blue; text-decoration: underline;">
                         Page @pageGroup.Key
                     </h4>
@@ -84,7 +83,7 @@
         </div>
 
         <div style="width: 60%; height: 100%;">
-            <iframe id="pdfViewer" width="100%" height="100%" frameborder="0"></iframe>
+            <iframe id="pdfViewer" src="@viewerSrc" width="100%" height="100%" frameborder="0"></iframe>
         </div>
     </div>
 }
@@ -100,6 +99,7 @@
     private readonly string[] HighlightPalette = new[] { "#ffff00", "#ffb6c1", "#90ee90", "#add8e6", "#ffa07a" };
     private Dictionary<Keyword, string> keywordColors = new();
     private int? _pendingPage;
+    private string? viewerSrc;
 
     private readonly System.Diagnostics.Stopwatch _stopwatch = new();
     private System.Timers.Timer? _timer;
@@ -242,8 +242,7 @@
     {
         var file = "/uploads/latest.pdf";
         var overlay = "/uploads/latest-highlights.json";
-        var viewerUrl = $"/pdfjs/index.html?file={Uri.EscapeDataString(file)}&page={page}&overlay={Uri.EscapeDataString(overlay)}";
-        await JS.InvokeVoidAsync("setIframeSrc", "pdfViewer", viewerUrl);
+        viewerSrc = $"/pdfjs/index.html?file={Uri.EscapeDataString(file)}&page={page}&overlay={Uri.EscapeDataString(overlay)}";
     }
 
     MarkupString HighlightKeywords(string text)

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -1,6 +1,1 @@
-function setIframeSrc(id, src) {
-    const iframe = document.getElementById(id);
-    if (iframe) {
-        iframe.src = src;
-    }
-}
+// Custom JavaScript is no longer required; file kept intentionally blank.


### PR DESCRIPTION
## Summary
- Bind PDF viewer iframe `src` directly from components and drop JS `setIframeSrc`
- Track viewer source string to navigate pages on clicks
- Remove unused JavaScript helper

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fb093b3c832cbe65fbbe7ff5185d